### PR TITLE
Center nav menu items vertically.

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -24,6 +24,12 @@ $jumbotron-bg: #fff;
 
 @import "bootstrap";
 
+.navbar-default {
+  ul.nav {
+    margin-top: 6px;
+  }
+}
+
 .footer {
   text-align: center;
 


### PR DESCRIPTION
Played with 5 and 6px down and 6 looked a little better zoomed in. Does not break anything at small screen sizes.
